### PR TITLE
feat(config): add `focus_window` setup option to enable focusing on open

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ require('plug').setup({
   clone_depth = 1,
   -- plugin priority, readme [plugin priority] for more info
   enable_priority = false,
+  -- enables the user to focus to the UI window when opened
+  focus_window = false,
 })
 ```
 

--- a/lua/plug/config.lua
+++ b/lua/plug/config.lua
@@ -25,6 +25,8 @@
 ---@field clone_depth? integer|string
 -- plugin priority, readme [plugin priority] for more info
 ---@field enable_priority? boolean
+-- enables the user to focus to the UI window when opened
+---@field focus_window? boolean
 ---@field import? string
 ---@field enable_luarocks? boolean
 ---@field dev_path? nil|string
@@ -42,6 +44,7 @@ M.clone_depth = '1'
 M.import = 'plugins'
 M.enable_priority = false
 M.enable_luarocks = false
+M.focus_window = false
 
 ---@param opt? PlugOpts
 function M.setup(opt)
@@ -56,6 +59,7 @@ function M.setup(opt)
   M.clone_depth = opt.clone_depth or M.clone_depth
   M.raw_plugin_dir = opt.raw_plugin_dir or M.raw_plugin_dir
   M.enable_priority = opt.enable_priority or M.enable_priority
+  M.focus_window = opt.focus_window or M.focus_window
   M.import = opt.import or M.import
   M.dev_path = opt.dev_path or M.dev_path
   M.enable_luarocks = opt.enable_luarocks or M.enable_luarocks

--- a/lua/plug/ui.lua
+++ b/lua/plug/ui.lua
@@ -114,7 +114,8 @@ function M.open()
     bufnr = vim.api.nvim_create_buf(false, true)
   end
   if not vim.api.nvim_win_is_valid(winid) then
-    winid = vim.api.nvim_open_win(bufnr, false, {
+    local focus = require('plug.config').focus_window
+    winid = vim.api.nvim_open_win(bufnr, focus, {
       split = 'left',
     })
   end


### PR DESCRIPTION
## Description

I think allowing the user to focus the `nvim-plug` window is a nice addition.

By default I set it to `false` for compatibility with your previous setup.
